### PR TITLE
Fixed race condition that affected Android + Chrome on mobile when a "sc...

### DIFF
--- a/src/wScratchPad.js
+++ b/src/wScratchPad.js
@@ -174,10 +174,15 @@
       e.pageY = Math.floor(e.pageY - this.canvasOffset.top);
       
       this['_scratch' + event](e);
-      
-      if (this.options.realtime || event === 'Up') {
+
+      if (this.options.realtime || event !== 'Move') {
         if (this.options['scratch' + event]) {
-          this.options['scratch' + event].apply(this, [e, this._scratchPercent()]);
+         // Setup callback to execute later, since scratch percentage calculation takes too long in some mobile browsers
+         // and will cause Chrome to fire a "touchcancel" event prematurely when touching down at first.
+         var _this = this;
+         setTimeout(function() {
+           _this.options['scratch' + event].apply(_this, [e, _this._scratchPercent()]);
+         }, 0);
         }
       }
     },
@@ -277,7 +282,7 @@
     size        : 5,          // The size of the brush/scratch.
     bg          : '#cacaca',  // Background (image path or hex color).
     fg          : '#6699ff',  // Foreground (image path or hex color).
-    realtime    : true,       // Calculates percentage in realitime
+    realtime    : true,       // Calculates percentage in real time (on move events, not just mouse up).
     scratchDown : null,       // Set scratchDown callback.
     scratchUp   : null,       // Set scratchUp callback.
     scratchMove : null,       // Set scratcMove callback.
@@ -292,6 +297,7 @@
 
       switch (event.type) {
       case 'touchstart':
+        event.preventDefault();
         type = 'mousedown';
         break;
       case 'touchmove':


### PR DESCRIPTION
I ended up with a race condition that affected Android + Chrome on mobile when a "scratchDown" callback was also setup. What happened was that the callback was being called with `this._scratchPercent()` being executed, which took some time in portrait mode but interestingly not landscape. Anyway, this caused Chrome 35 to automatically trigger a `touchcancel` event since it took longer than 200ms to respond, which foobar'ed everything, causing `touchmove` events never to be fired and thus created bullet holes instead of lines when attempting to scratch (just dropped a circle and did nothing else).

Fixed involves deferring callbacks via `setTimeout()` so that `touchstart` will return immediately. I also modified the logic on firing callbacks slightly to just exclude `scratchMove` if not currently set to `realtime` in the options.
