### PR TITLE
Add a new option for percent update between realtime and scratchUp

### DIFF
--- a/src/wScratchPad.js
+++ b/src/wScratchPad.js
@@ -127,6 +127,11 @@
           });
         }
       }
+
+      // If delay, create a global variable to store the next percent update
+      if(this.options.delay){
+        this.nextPercentUpdate = null;
+      }
     },
 
     clear: function () {
@@ -174,8 +179,16 @@
       e.pageY = Math.floor(e.pageY - this.canvasOffset.top);
       
       this['_scratch' + event](e);
-      
-      if (this.options.realtime || event === 'Up') {
+
+      if(this.options.delayed){
+        if(this.options['scratch' + event]) {
+          var currentDate = new Date().getTime();
+          if(this.nextPercentUpdate == null || this.nextPercentUpdate < currentDate){
+            this.nextPercentUpdate = currentDate + this.options.delayed;
+            this.options['scratch' + event].apply(this, [e, this._scratchPercent()]);
+          }
+        }
+      } else if(this.options.realtime || event === 'Up'){
         if (this.options['scratch' + event]) {
           this.options['scratch' + event].apply(this, [e, this._scratchPercent()]);
         }


### PR DESCRIPTION
I needed to have compromise between the realtime percent update and scratch up for a project on mobile.
I added a delayed option which fake realtime. You can specify the time between two percent update in millisecond.
