### PR TITLE
Update wScratchPad.js

### DIFF
--- a/src/wScratchPad.js
+++ b/src/wScratchPad.js
@@ -285,7 +285,7 @@
   };
 
   $.fn.bindMobileEvents = function () {
-    $(this).on('touchstart touchmove touchend touchcancel', function (event) {
+    var eventFunc = function (event) {
       var touches = (event.changedTouches || event.originalEvent.targetTouches),
           first = touches[0],
           type = '';
@@ -314,6 +314,9 @@
       );
 
       first.target.dispatchEvent(simulatedEvent);
+    });
+    $(this).on('touchstart touchmove touchcancel', eventFunc).each(function () {
+      this.addEventListener('touchend', eventFunc);
     });
   };
 })(jQuery);


### PR DESCRIPTION
jQuery appears to not populate the event with changedTouches when dealing with touchend event with android devices. This fix cuts jQuery out of the equation and you observe a fully populated touchend event.
