### PR TITLE
Enable Origin headers when fetching foreground image to support CORS.

### DIFF
--- a/src/wScratchPad.js
+++ b/src/wScratchPad.js
@@ -120,6 +120,7 @@
         else {
           // Have to load image before we can use it.
           $(new Image())
+          .attr('crossOrigin', '')
           .attr('src', this.options.fg)
           .load(function () {
             _this.ctx.drawImage(this, 0, 0, width, height);


### PR DESCRIPTION
Hi,

Presently `Origin` headers are not being sent out when fetching the foreground image. It was enabled for the background image earlier.

This should fix the issue.