### PR TITLE
Gray border problem in chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $("#elem").wScratchPad('image', './images/winner.png');
 ```js
 $('#elem').wScratchPad('reset');
 $('#elem').wScratchPad('clear');
-$('#elem').wScratchPad('enabled', <boolean>);
+$('#elem').wScratchPad('enable', <boolean>);
 ```
 
 

--- a/src/wScratchPad.js
+++ b/src/wScratchPad.js
@@ -29,7 +29,7 @@
         this.$el.css('position', 'relative');
       }
 
-      this.$img = $('<img src=""/>').attr('crossOrigin', '').css({position: 'absolute', width: '100%', height: '100%'});
+      this.$img = $('<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"/>').attr('crossOrigin', '').css({position: 'absolute', width: '100%', height: '100%'});
 
       // Make sure we sett style width height here for elastic stretch
       // and better support for mobile if we are resizing the scratch pad.


### PR DESCRIPTION
There is a thin gray border around the embedded `img`. This is something chrome does when the `src` is empty (or invalid). One approach is to use padding of the image as apposed to width/height and another solution is to use a 1x1 transparent pixel for the src.

While i was at it, i also fixed the readme text (issue #14)